### PR TITLE
fix: rasterization missing import

### DIFF
--- a/rasterization-practical-implementation/geometry.h
+++ b/rasterization-practical-implementation/geometry.h
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <iomanip>
 #include <cmath>
+#include <cstdint>
 
 template<typename T>
 class Vec2


### PR DESCRIPTION
I tried to compile the rasterisation-practical-implementation example using `g++ (GCC) 15.1.1 20250425`. The following command:
`g++ raster3d.cpp -o test`
gives a compile error which suggests cstdint is missing. Adding the import statement fixes the compile error (and the code runs and produces a raster successfully).